### PR TITLE
Added feature to automatically refresh package meta if ttl expired.

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ parameters are available:
   as a daemon (default="")
 * NOPAR_RUNAS_USER - The user to run as if running as a daemon, empty for not
   running as a daemon (default="")
+* NOPAR_META_TTL - The time in seconds until attempting to refresh metadata from
+  "upstream registry" (default=21600)
 
 If the environment variable ``NOPAR_RUNAS_USER`` is set, the service will run
 as a daemon.
@@ -105,7 +107,3 @@ Known Issues
 ------------
 
 * Missing user management. Welcome to the "Admin Party"!
-* Once a package meta is cached, it doesn't get updated from the
-  [upstream registry](http://registry.npmjs.org) automatically. You can refresh
-  the package meta from the [upstream registry](http://registry.npmjs.org) by
-  clicking on the "Refresh" link for that package in the user interface.

--- a/lib/pkg.js
+++ b/lib/pkg.js
@@ -7,6 +7,8 @@ var path       = require("path");
 var url        = require("url");
 var winston    = require("winston");
 var attachment = require("./attachment");
+var settings   = require("./settings");
+
 
 function increaseRevision(rev) {
   rev = Number(rev);
@@ -123,6 +125,22 @@ exports.getPackage = function (app) {
     var settings = app.get("settings");
 
     var pkgMeta = registry.getPackage(packagename);
+    // Refresh from external if: No version was given and ttl expired
+    if (pkgMeta && pkgMeta["_proxied"] && !version &&
+        pkgMeta["_mtime"].getTime() + (settings.get("metaTTL") * 1000) < new Date().getTime()) {
+      winston.info("maxTTL expired for package " + packagename);
+      return proxyPackage(registry, settings, packagename, version,
+        function (err) {
+          if (err) {
+            winston.warn("Failed to refresh metadata!", err.text, err.details, "Returning cached version.");
+            // Send back cached version on failure
+            return res.json(200, registry.getPackage(packagename, version));
+          }
+
+          res.json(200, registry.getPackage(packagename, version));
+        }
+      );
+    }
     if (!pkgMeta ||
         (version && pkgMeta.versions && !pkgMeta.versions[version])) {
 

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -240,6 +240,9 @@ exports.getPackage = function (pkgName, version) {
   } catch (e) {
     throw new Error("Failed to parse package meta: " + pkgMetaPath + "; got: " + pkgMeta);
   }
+  // Extend metadata modified time, used to calculate ttl expiry
+  pkgMeta["_mtime"] = fs.statSync(pkgMetaPath).mtime;
+
 
   if (version) {
     return pkgMeta.versions ? pkgMeta.versions[version] : null;

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -26,7 +26,8 @@ var defaults = {
                             process.env.NOPAR_IGNORE_CERT === undefined ||
                             process.env.NOPAR_IGNORE_CERT === "") ? false :
                             (process.env.NOPAR_IGNORE_CERT === "yes" ? true : false),
-  "forwarder.userAgent"   : process.env.NOPAR_USER_AGENT || "nopar/" + me.version
+  "forwarder.userAgent"   : process.env.NOPAR_USER_AGENT || "nopar/" + me.version,
+  "metaTTL"               : process.env.NOPAR_META_TTL || 60 * 60 * 6 // Seconds
 };
 exports.defaults = defaults;
 

--- a/test/pkg-test.js
+++ b/test/pkg-test.js
@@ -50,7 +50,7 @@ buster.testCase("pkg-test - getPackage", {
   },
 
   "should return full package": function () {
-    var pkgMeta = { a : "b" };
+    var pkgMeta = { a : "b", "_mtime": new Date() };
     this.app.get.withArgs("registry").returns({
       getPackage : this.stub().returns(pkgMeta)
     });

--- a/test/registry-test.js
+++ b/test/registry-test.js
@@ -209,7 +209,7 @@ buster.testCase("registry-test - get pkg version", {
     var result = registry.getPackage("pkg");
 
     assert.calledWith(fs.readFileSync, "/some/path/registry/pkg/pkg.json");
-    assert.equals(result, OLD_META.pkg);
+    assert.equals(result.versions, OLD_META.pkg.versions);
   },
 
   "should return null if package version does not exist": function () {

--- a/test/settings-test.js
+++ b/test/settings-test.js
@@ -46,7 +46,8 @@ buster.testCase("settings-test - init", {
       hostname                : defaults.hostname,
       logfile                 : defaults.logfile,
       port                    : defaults.port,
-      registryPath            : defaults.registryPath
+      registryPath            : defaults.registryPath,
+      metaTTL                 : defaults.metaTTL
     });
     assert.equals(s.data["forwarder.registry"], defaults["forwarder.registry"]);
     assert.equals(s.data["forwarder.proxy"], defaults["forwarder.proxy"]);
@@ -55,6 +56,7 @@ buster.testCase("settings-test - init", {
     assert.equals(s.data["forwarder.userAgent"], defaults["forwarder.userAgent"]);
     assert.equals(s.data.hostname, defaults.hostname);
     assert.equals(s.data.port, defaults.port);
+    assert.equals(s.data.metaTTL, defaults.metaTTL);
   },
 
   "should set autoForward to default if null": function () {


### PR DESCRIPTION
There are no test cases specific to this new feature. Maybe someone with buster knowledge could assist?
