### PR TITLE
Handle new npm atomic publish

### DIFF
--- a/lib/attachment.js
+++ b/lib/attachment.js
@@ -228,6 +228,58 @@ exports.detach = function (app) {
   };
 };
 
+/**
+ * Extract any tarballs the client has uploaded via _attachments
+ *
+ * @see https://github.com/npm/npm-skim-registry/blob/841ad861f34c0bc14bf0b113537b4faf17cac70a/skim.js#L99
+ *
+ * @param  {settings} settings
+ * @param  {string}   pkgMeta  client uploaded package.json with attachments
+ * @param  {Function} cb       callback
+ */
+exports.skimTarballs = function(settings, pkgMeta, cb) {
+  if (!pkgMeta["_attachments"] || !pkgMeta.versions) {
+    return cb();
+  }
+
+  var attachments = pkgMeta["_attachments"];
+  delete pkgMeta["_attachments"];
+
+  var pkgPath = makePackagePath(settings.get("registryPath"), pkgMeta.name);
+
+  var toSave = 0;
+  Object.keys(pkgMeta.versions).forEach(function(v) {
+    var p = pkgMeta.versions[v];
+    var attachment = p.dist.tarball.substr(
+                     p.dist.tarball.lastIndexOf("/") + 1);
+    if (attachments[attachment]) {
+      saveTarball(attachment, attachments[attachment].data);
+    }
+  });
+
+  function saveTarball(attachment, base64data) {
+    ++toSave;
+    fs.writeFile(path.join(pkgPath, attachment), base64data, {
+      flags    : "w",
+      encoding : "base64",
+      mode     : "0660"
+    }, onSaveComplete);
+  }
+
+  if (!toSave) {
+    return cb();
+  }
+
+  function onSaveComplete(err) {
+    if (err) {
+      cb(err);
+      cb = function(){};
+    } else if (--toSave === 0) {
+      cb();
+    }
+  }
+};
+
 exports.refreshMeta = function (settings, pkgMeta) {
   var attachments = {};
   var packagename = pkgMeta.name;

--- a/lib/pkg.js
+++ b/lib/pkg.js
@@ -151,7 +151,7 @@ exports.getPackage = function (app) {
  * https://github.com/isaacs/npmjs.org#put-packagename
  */
 exports.publishFull = function (app) {
-  return function (req, res) {
+  return function (req, res, next) {
     winston.info("PUT " + req.originalUrl, req.body);
     if (req.headers["content-type"] !== "application/json") {
       return res.json(400, {
@@ -165,26 +165,42 @@ exports.publishFull = function (app) {
     var settings    = app.get("settings");
 
     var pkgMeta     = registry.getPackage(packagename);
-    if (pkgMeta && !req.params.revision) {
+
+    var newPkgMeta = req.body || {};
+    var incomingRevision = req.params.revision || newPkgMeta["_rev"];
+
+    if (pkgMeta && !incomingRevision) {
       return res.json(409, {
         "error"  : "conflict",
         "reason" : "must supply latest _rev to update existing package"
       });
     }
-    if (pkgMeta && ("" + req.params.revision) !== ("" + pkgMeta["_rev"])) {
+    if (pkgMeta && ("" + incomingRevision) !== ("" + pkgMeta["_rev"])) {
       return res.json(409, {
         "error"  : "conflict",
         "reason" : "revision does not match one in document"
       });
     }
 
-    pkgMeta = req.body || {};
-    pkgMeta["_rev"] = increaseRevision(pkgMeta["_rev"]);
-    pkgMeta["_proxied"] = false;
-    attachment.refreshMeta(settings, pkgMeta);
-    registry.setPackage(pkgMeta);
+    // If we have attachments in the upload, store them
+    if (newPkgMeta._attachments) {
+      attachment.skimTarballs(settings, newPkgMeta, updateAndPersist);
+    } else {
+      updateAndPersist();
+    }
 
-    res.json(200, {"ok" : true});
+    function updateAndPersist(err) {
+      if (err) return next(err);
+
+      pkgMeta = newPkgMeta;
+      pkgMeta["_rev"] = increaseRevision(pkgMeta["_rev"]);
+      pkgMeta["_proxied"] = false;
+      attachment.refreshMeta(settings, pkgMeta);
+      registry.setPackage(pkgMeta);
+
+      res.json(200, {"ok" : true});
+    }
+
   };
 };
 

--- a/test/attachment-test.js
+++ b/test/attachment-test.js
@@ -305,7 +305,7 @@ buster.testCase("attachment-test - attach", {
     assert.isFunction(attachment.attach);
   },
 
-  "should require content-type application/json": function () {
+  "should require content-type application/octet-stream": function () {
     this.attachFn({
       headers     : {},
       params      : { packagename : "test" },
@@ -344,6 +344,89 @@ buster.testCase("attachment-test - attach", {
     });
     assert.called(this.req.pipe);
     assert.calledWith(this.req.pipe, "MY_FD");
+  }
+});
+
+
+// ==== Test Case
+
+buster.testCase("attachment-test - skimTarballs", {
+  setUp: function () {
+    this.stub(fs, "writeFile").yields();
+
+    var tarball = new Buffer("I'm a tarball");
+    this.tarballBase64 = tarball.toString('base64');
+
+    this.pkgMeta = {
+      "_id"  : "test",
+      "name" : "test",
+      "versions": {
+        "0.0.1": {
+          "dist": {
+            "shasum": "0dd79a57eae458d4b9cf7adc59813cdf812deef9",
+            "tarball": "http://localhost:5984/test/-/test-0.0.1.tgz"
+          }
+        }
+      },
+      "_attachments": {
+        "test-0.0.1.tgz": {
+          "content-type": "application/octet-stream",
+          "data": this.tarballBase64,
+          "length": tarball.byteLength
+        }
+      }
+    };
+
+    this.settings = {
+      get : this.stub()
+    };
+    this.settings.get.withArgs("registryPath").returns("/path");
+  },
+
+  "should have function": function () {
+    assert.isFunction(attachment.skimTarballs);
+  },
+
+  "does nothing with no attachments": function () {
+    var callback = this.spy();
+
+    attachment.skimTarballs(this.settings, {}, callback);
+
+    refute.called(fs.writeFile);
+    assert.called(callback);
+  },
+
+  "should create path if it doesn't exist": function () {
+    this.stub(fs, "existsSync").returns(false);
+    this.stub(fs, "mkdirSync");
+
+    var callback = this.spy();
+
+    attachment.skimTarballs(this.settings, this.pkgMeta, callback);
+
+    assert.called(fs.mkdirSync);
+    assert.calledWith(fs.mkdirSync, "/path/test");
+
+    assert.called(callback);
+  },
+
+  "should write tarball to disk": function () {
+    this.stub(fs, "existsSync").returns(true);
+
+    var callback = this.spy();
+
+    attachment.skimTarballs(this.settings, this.pkgMeta, callback);
+
+    assert.called(fs.writeFile);
+    assert.calledWith(fs.writeFile,
+      "/path/test/test-0.0.1.tgz", this.tarballBase64,
+      {
+        flags    : "w",
+        encoding : 'base64',
+        mode     : "0660"
+      });
+
+    assert.called(callback);
   }
 });
 


### PR DESCRIPTION
As mentioned in #14 new npm clients now do a single PUT that contains the tarball inline.

They also handle 409 responses slightly differently, merging with the current state and re-doing the PUT to the same URL.

This branch adds support for new clients while retaining backwards compatibility. I've added tests and tried this out with both old and new npm clients 
