### PR TITLE
callback should be called when writesteam fires finish, not on response ...

### DIFF
--- a/lib/attachment.js
+++ b/lib/attachment.js
@@ -67,7 +67,7 @@ function proxyFile(settings, packagename, filename, forwardUrl, cb) {
         JSON.stringify(err), err);
       cb(err);
     });
-    res.on("end", function () {
+    out.on("finish", function () {
       cb();
     });
     res.pipe(out);


### PR DESCRIPTION
...end. 
request.on("end") fires earlier than file is actually created on disk, and sometimes, especially on slower devices you get response error.
