### PR TITLE
callback should be called when writesteam fires finish, not on response end

### DIFF
--- a/lib/attachment.js
+++ b/lib/attachment.js
@@ -68,10 +68,10 @@ function proxyFile(settings, packagename, filename, forwardUrl, cb) {
       cb(err);
     });
     //node v0.10
-    out.on("finish", function () {
-      cb();
-    });
-    //node v0.8
+    // out.on("finish", function () {
+    //   cb();
+    // });
+    //fires on both node v0.8 & v0.10
     out.on("close", function () {
       cb();
     });


### PR DESCRIPTION
request.on("end") fires earlier than file is actually created on disk, and sometimes, especially on slower devices you get response error.
