### PR TITLE
Use NOPAR_BASE_URL.

### DIFF
--- a/lib/settings.js
+++ b/lib/settings.js
@@ -29,7 +29,7 @@ var defaults = {
   "forwarder.userAgent"   : process.env.NOPAR_USER_AGENT || "nopar/" + me.version,
   "metaTTL"               : process.env.NOPAR_META_TTL || 60 * 60 * 6 // Seconds
 };
-defaults.baseUrl = process.env.NOPAR_baseUrl || "http://" + defaults.hostname + ":" + defaults.port;
+defaults.baseUrl = process.env.NOPAR_BASE_URL || "http://" + defaults.hostname + ":" + defaults.port;
 exports.defaults = defaults;
 
 function getRenderer(settings) {


### PR DESCRIPTION
It was using `NOPAR_baseUrl` previously.
