### PR TITLE
Keep latest tag at latest version is published version is smaller

### DIFF
--- a/lib/pkg.js
+++ b/lib/pkg.js
@@ -2,10 +2,12 @@
 /*globals */
 /*! Copyright (C) 2013 by Andreas F. Bobak, Switzerland. All Rights Reserved. !*/
 
-var fs         = require("fs");
-var path       = require("path");
-var url        = require("url");
-var winston    = require("winston");
+var fs      = require("fs");
+var path    = require("path");
+var semver  = require("semver");
+var url     = require("url");
+var winston = require("winston");
+
 var attachment = require("./attachment");
 var settings   = require("./settings");
 
@@ -256,9 +258,12 @@ exports.publish = function (app) {
       if (!pkgMeta["dist-tags"]) {
         pkgMeta["dist-tags"] = {};
       }
-      pkgMeta["dist-tags"]["latest"] = version;
-      pkgMeta.description = pkgMeta["versions"][version].description;
-      pkgMeta.readme = pkgMeta["versions"][version].readme;
+      var latest = pkgMeta["dist-tags"]["latest"] || "0.0.0";
+      if (semver.gt(version, latest)) {
+        pkgMeta["dist-tags"]["latest"] = version;
+        pkgMeta.description = pkgMeta["versions"][version].description;
+        pkgMeta.readme = pkgMeta["versions"][version].readme;
+      }
     }
     pkgMeta["_rev"] = increaseRevision(pkgMeta["_rev"]);
     pkgMeta["_proxied"] = false;

--- a/test/pkg-test.js
+++ b/test/pkg-test.js
@@ -778,12 +778,11 @@ describe("pkg-test - publish", function () {
   it("should reset revision if it's a checksum", function () {
     /*jslint nomen: true*/
     var pkgMeta = {
-      name       : "test",
-      "_rev"     : "011f2254e3def8ab3023052072195e1a",
-      "_proxied" : false,
-      versions   : {
-        "0.0.1-dev" : {}
-      }
+      name        : "test",
+      "_rev"      : "011f2254e3def8ab3023052072195e1a",
+      "_proxied"  : false,
+      "dist-tags" : { latest : "0.0.1-dev" },
+      versions    : { "0.0.1-dev" : {} }
     };
     this.getPackageStub.returns(pkgMeta);
 
@@ -834,6 +833,38 @@ describe("pkg-test - publish", function () {
     sinon.assert.called(this.setPackageStub);
     sinon.assert.calledWith(this.setPackageStub, pkgMeta);
     sinon.assert.called(this.res.json);
+    sinon.assert.calledWith(this.res.json, 200, "\"0.0.1-dev\"");
+  });
+
+  it("should keep latest if version<latest", function () {
+    /*jslint nomen: true*/
+    var pkgMeta = {
+      name        : "test",
+      "_rev"      : 0,
+      "_proxied"  : false,
+      "dist-tags" : { latest : "0.0.2" },
+      versions    : { "0.0.2" : {} }
+    };
+    this.getPackageStub.returns(pkgMeta);
+
+    this.publishFn({
+      headers     : { "content-type" : "application/json" },
+      params      : {
+        packagename : "test",
+        version     : "0.0.1-dev",
+        tagname     : "latest"
+      },
+      originalUrl : "/test/0.0.1-dev/-tag/latest"
+    }, this.res);
+
+    pkgMeta = {
+      name        : "test",
+      "_rev"      : 1,
+      "_proxied"  : false,
+      "dist-tags" : { latest : "0.0.2" },
+      versions    : { "0.0.2" : {}, "0.0.1-dev": {} }
+    };
+    sinon.assert.calledWith(this.setPackageStub, pkgMeta);
     sinon.assert.calledWith(this.res.json, 200, "\"0.0.1-dev\"");
   });
 });


### PR DESCRIPTION
Currently if there's a package with version 2.0 in the repository and a package with version 1.9 gets published, 1.9 will be tagged as "latest". This pull request leaves the latest tag untouched if a package with a smaller version is published.
