### PR TITLE
Proxy & publish scoped packages

### DIFF
--- a/lib/attachment.js
+++ b/lib/attachment.js
@@ -260,13 +260,28 @@ exports.skimTarballs = function(settings, pkgMeta, cb) {
   var pkgPath = makePackagePath(settings.get("registryPath"), pkgMeta.name);
 
   var toSave = 0;
-  Object.keys(pkgMeta.versions).forEach(function(v) {
-    var p = pkgMeta.versions[v];
-    var attachment = p.dist.tarball.substr(
-                     p.dist.tarball.lastIndexOf("/") + 1);
-    if (attachments[attachment] && attachments[attachment].data) {
-      saveTarball(attachment, attachments[attachment].data);
+  function findDist(attachment) {
+    var found = null;
+    Object.keys(pkgMeta.versions).some(function (v) {
+      var dist = pkgMeta.versions[v].dist;
+      if (dist.tarball.substr(0 - attachment.length) === attachment) {
+        found = dist;
+        return true;
+      }
+    });
+    return found;
+  }
+  Object.keys(attachments).forEach(function(attachment) {
+    if (!attachments[attachment].data) {
+      return;
     }
+    var dist = findDist(attachment);
+    if (!dist) {
+      return;
+    }
+    var basename = path.basename(attachment);
+    dist.tarball = dist.tarball.replace(attachment, basename);
+    saveTarball(basename, attachments[attachment].data);
   });
 
   function saveTarball(attachment, base64data) {

--- a/lib/attachment.js
+++ b/lib/attachment.js
@@ -10,6 +10,12 @@ var registry = require("../lib/registry");
 
 function makePackagePath(registryPath, packagename) {
   var pkgPath = path.join(registryPath, packagename);
+  if (packagename[0] === '@') {
+    var scopedDir = path.dirname(pkgPath);
+    if (!fs.existsSync(scopedDir)) {
+      fs.mkdirSync(scopedDir, "770");
+    }
+  }
   if (!fs.existsSync(pkgPath)) {
     fs.mkdirSync(pkgPath, "770");
   }

--- a/lib/pkg.js
+++ b/lib/pkg.js
@@ -23,6 +23,13 @@ function increaseRevision(rev) {
   return rev + 1;
 }
 
+function escapePackageName(name) {
+  if (name[0] === '@') {
+    return name.replace(/\//, '%2f');
+  }
+  return name;
+}
+
 function proxyPackage(registry, settings, packagename, version, cb) {
   var registryUrl = settings.get("forwarder.registry");
   if (!registryUrl) {
@@ -36,7 +43,7 @@ function proxyPackage(registry, settings, packagename, version, cb) {
   proxyUrl     = proxyUrl ? url.parse(proxyUrl) : null;
 
   registryUrl           = url.parse(registryUrl);
-  registryUrl.pathname += packagename;
+  registryUrl.pathname += escapePackageName(packagename);
 
   winston.info("Retrieving package " + packagename + "@" + (version || "*") +
     " from forward URL " + url.format(registryUrl));
@@ -143,6 +150,7 @@ exports.enhancePackage = function (pkg) {
     }
   }
   pkg.repository = repository;
+  pkg.path = escapePackageName(pkg.name);
 
   try {
     pkg["_versions"] = Object.keys(pkg.versions).sort(semver.compare);

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -142,37 +142,50 @@ exports.refreshMeta = function (settings) {
   meta.local   = 0;
   meta.proxied = 0;
 
-  for (var i = pkgs.length - 1; i >= 0; i--) {
-    var name = pkgs[i];
-    if (fs.statSync(path.join(registryPath, name)).isDirectory()) {
-      var pkgMeta = exports.getPackage(name);
-      if (!pkgMeta) {
-        winston.warn("Package folder '" + name + "' is missing meta JSON.");
-        continue;
-      }
-      attachment.refreshMeta(settings, pkgMeta);
+  function processPackage(name) {
+    var pkgMeta = exports.getPackage(name);
+    if (!pkgMeta) {
+      winston.warn("Package folder '" + name + "' is missing meta JSON.");
+      return;
+    }
+    attachment.refreshMeta(settings, pkgMeta);
 
-      if (!meta.count) {
-        meta.count = 1;
-      } else {
-        meta.count++;
-      }
+    if (!meta.count) {
+      meta.count = 1;
+    } else {
+      meta.count++;
+    }
 
-      if (pkgMeta["_proxied"]) {
-        if (!meta.proxied) {
-          meta.proxied = 1;
-        } else {
-          meta.proxied++;
-        }
+    if (pkgMeta["_proxied"]) {
+      if (!meta.proxied) {
+        meta.proxied = 1;
       } else {
-        if (!meta.local) {
-          meta.local = 1;
-        } else {
-          meta.local++;
-        }
+        meta.proxied++;
+      }
+    } else {
+      if (!meta.local) {
+        meta.local = 1;
+      } else {
+        meta.local++;
       }
     }
   }
+
+  pkgs.forEach(function(name) {
+    var pkgPath = path.join(registryPath, name);
+    if (fs.statSync(pkgPath).isDirectory()) {
+      if (name[0] === '@') {
+        fs.readdirSync(pkgPath).forEach(function(scopedPkg) {
+          var scopedPkgPath = path.join(registryPath, name, scopedPkg);
+          if (fs.statSync(scopedPkgPath).isDirectory()) {
+            processPackage(path.join(name, scopedPkg));
+          }
+        });
+      } else {
+        processPackage(name);
+      }
+    }
+  });
 
   writeMeta();
 
@@ -243,7 +256,8 @@ exports.getPackage = function (pkgName, version, settings) {
       return null;
     }
 
-    var pkgMetaPath = path.join(pkgPath, pkgName + ".json");
+    // Basename excludes @scoped part of name
+    var pkgMetaPath = path.join(pkgPath, path.basename(pkgName) + ".json");
     if (!fs.existsSync(pkgMetaPath)) {
       return null;
     }
@@ -307,7 +321,13 @@ exports.setPackage = function (pkgMeta) {
 
   var pkgName     = pkgMeta.name;
   var pkgPath     = path.join(registryPath, pkgName);
-  var pkgMetaPath = path.join(pkgPath, pkgName + ".json");
+  var pkgMetaPath = path.join(pkgPath, path.basename(pkgName) + ".json");
+  if (pkgName[0] === '@') {
+    var scopeDir = path.dirname(pkgPath);
+    if (!fs.existsSync(scopeDir)) {
+      fs.mkdirSync(scopeDir);
+    }
+  }
   if (!fs.existsSync(pkgPath)) {
     fs.mkdirSync(pkgPath);
   }
@@ -351,7 +371,7 @@ exports.removePackage = function (pkgName) {
     return;
   }
 
-  var pkgMetaPath = path.join(pkgPath, pkgName + ".json");
+  var pkgMetaPath = path.join(pkgPath, path.basename(pkgName) + ".json");
   if (!fs.existsSync(pkgMetaPath)) {
     return;
   }
@@ -374,20 +394,32 @@ function iteratePackages(all, settings, fn) {
     fn = settings;
     settings = null;
   }
-  for (var i = all.length - 1; i >= 0; i--) {
-    var name = all[i];
+
+  function tryPackage(name) {
     var pkgMeta;
 
-    if (packageCache[pkgMeta]) {
-      pkgMeta = packageCache[pkgMeta];
-    } else if (fs.statSync(path.join(registryPath, name)).isDirectory()) {
-      pkgMeta = exports.getPackage(name, null, settings);
+    if (packageCache[name]) {
+      pkgMeta = packageCache[name];
+    } else {
+      var dir = path.join(registryPath, name);
+      if (fs.statSync(dir).isDirectory()) {
+        if (name[0] === '@') {
+          fs.readdirSync(dir).forEach(function(pkg) {
+            tryPackage(path.join(name, pkg));
+          });
+          return;
+        } else {
+          pkgMeta = exports.getPackage(name, null, settings);
+        }
+      }
     }
 
     if (pkgMeta) {
       fn(name, pkgMeta);
     }
   }
+
+  all.forEach(tryPackage);
 }
 
 exports.iteratePackages = function (fn) {

--- a/test/attachment-test.js
+++ b/test/attachment-test.js
@@ -375,6 +375,24 @@ describe("attachment-test - attach", function () {
     sinon.assert.called(this.req.pipe);
     sinon.assert.calledWith(this.req.pipe, "MY_FD");
   });
+
+  it("should create scoped write stream and pipe to it", function () {
+    sandbox.stub(fs, "existsSync").returns(true);
+    fs.createWriteStream.returns("MY_FD");
+
+    this.req.params.name = '@scoped/test';
+
+    this.attachFn(this.req, this.res);
+
+    sinon.assert.called(fs.createWriteStream);
+    sinon.assert.calledWith(fs.createWriteStream, "/path/@scoped/test/test.tgz", {
+      flags    : "w",
+      encoding : null,
+      mode     : "0660"
+    });
+    sinon.assert.called(this.req.pipe);
+    sinon.assert.calledWith(this.req.pipe, "MY_FD");
+  });
 });
 
 
@@ -404,6 +422,26 @@ describe("attachment-test - skimTarballs", function () {
       },
       "_attachments": {
         "test-0.0.1.tgz": {
+          "content-type": "application/octet-stream",
+          "data": this.tarballBase64,
+          "length": tarball.byteLength
+        }
+      }
+    };
+
+    this.scopedMeta = {
+      "_id"  : "@scopped/test",
+      "name" : "@scoped/test",
+      "versions": {
+        "0.0.1": {
+          "dist": {
+            "shasum": "0dd79a57eae458d4b9cf7adc59813cdf812deef9",
+            "tarball": "http://localhost:5984/@scoped/test/-/@scoped/test-0.0.1.tgz"
+          }
+        }
+      },
+      "_attachments": {
+        "@scoped/test-0.0.1.tgz": {
           "content-type": "application/octet-stream",
           "data": this.tarballBase64,
           "length": tarball.byteLength
@@ -448,6 +486,21 @@ describe("attachment-test - skimTarballs", function () {
     sinon.assert.called(callback);
   });
 
+  it("should create scoped path if it doesn't exist", function () {
+    sandbox.stub(fs, "existsSync").returns(false);
+    sandbox.stub(fs, "mkdirSync");
+
+    var callback = sandbox.spy();
+
+    attachment.skimTarballs(this.settingsStore, this.scopedMeta, callback);
+
+    sinon.assert.called(fs.mkdirSync);
+    sinon.assert.calledWith(fs.mkdirSync, "/path/@scoped");
+    sinon.assert.calledWith(fs.mkdirSync, "/path/@scoped/test");
+
+    sinon.assert.called(callback);
+  });
+
   it("should write tarball to disk", function () {
     sandbox.stub(fs, "existsSync").returns(true);
 
@@ -458,6 +511,25 @@ describe("attachment-test - skimTarballs", function () {
     sinon.assert.called(fs.writeFile);
     sinon.assert.calledWith(fs.writeFile,
       "/path/test/test-0.0.1.tgz", this.tarballBase64,
+      {
+        flags    : "w",
+        encoding : 'base64',
+        mode     : "0660"
+      });
+
+    sinon.assert.called(callback);
+  });
+
+  it("should write tarball to disk", function () {
+    sandbox.stub(fs, "existsSync").returns(true);
+
+    var callback = sandbox.spy();
+
+    attachment.skimTarballs(this.settingsStore, this.scopedMeta, callback);
+
+    sinon.assert.called(fs.writeFile);
+    sinon.assert.calledWith(fs.writeFile,
+      "/path/@scoped/test/test-0.0.1.tgz", this.tarballBase64,
       {
         flags    : "w",
         encoding : 'base64',

--- a/test/pkg-test.js
+++ b/test/pkg-test.js
@@ -530,6 +530,37 @@ describe("pkg-test - publishFull", function () {
     sinon.assert.calledWith(this.json, {"ok" : true});
   });
 
+  it("should add package and persist registry for new scoped package", function () {
+    registry.getPackage.returns(null);
+
+    this.publishFullFn({
+      settingsStore : this.settingsStore,
+      headers       : { "content-type" : "application/json" },
+      params        : { name : "@scoped/test" },
+      originalUrl   : "/@scoped%2ftest",
+      body          : {
+        "_id"  : "@scoped/test",
+        "name" : "@scoped/test"
+      }
+    }, this.res);
+
+    var pkgMeta = {
+      "_id"      : "@scoped/test",
+      "name"     : "@scoped/test",
+      "_rev"     : 1,
+      "_proxied" : false
+    };
+    sinon.assert.called(attachment.refreshMeta);
+    sinon.assert.calledWith(attachment.refreshMeta, this.settingsStore,
+      pkgMeta);
+    sinon.assert.called(registry.setPackage);
+    sinon.assert.calledWith(registry.setPackage, pkgMeta);
+    sinon.assert.calledOnce(this.res.status);
+    sinon.assert.calledWith(this.res.status, 200);
+    sinon.assert.called(this.json);
+    sinon.assert.calledWith(this.json, {"ok" : true});
+  });
+
   it("should skim off attachment and persist for new package", function () {
     registry.getPackage.returns(null);
 
@@ -563,6 +594,53 @@ describe("pkg-test - publishFull", function () {
     var newPkgMeta = {
       "_id"      : "test",
       "name"     : "test",
+      "_rev"     : 1,
+      "_proxied" : false
+    };
+    sinon.assert.called(attachment.refreshMeta);
+    sinon.assert.calledWith(attachment.refreshMeta, this.settingsStore,
+      newPkgMeta);
+    sinon.assert.called(registry.setPackage);
+    sinon.assert.calledWith(registry.setPackage, newPkgMeta);
+    sinon.assert.calledOnce(this.res.status);
+    sinon.assert.calledWith(this.res.status, 200);
+    sinon.assert.called(this.json);
+    sinon.assert.calledWith(this.json, {"ok" : true});
+  });
+
+  it("should skim off attachment and persist for new scoped package", function () {
+    registry.getPackage.returns(null);
+
+    var tarballBytes = new Buffer("I'm a tarball");
+    var tarballBase64 = tarballBytes.toString('base64');
+
+    var pkgMeta = {
+      "_id"  : "@scoped/test",
+      "name" : "@scoped/test",
+      "_attachments": {
+        "@scoped/test-0.0.1.tgz": {
+          "content-type": "application/octet-stream",
+          "data": tarballBase64,
+          "length": tarballBytes.byteLength
+        }
+      }
+    };
+
+    this.publishFullFn({
+      settingsStore : this.settingsStore,
+      headers       : { "content-type" : "application/json" },
+      params        : { name : "@scoped/test" },
+      originalUrl   : "/@scoped%2ftest",
+      body          : pkgMeta
+    }, this.res);
+
+    sinon.assert.called(attachment.skimTarballs);
+    sinon.assert.calledWith(attachment.skimTarballs, this.settingsStore,
+      pkgMeta);
+
+    var newPkgMeta = {
+      "_id"      : "@scoped/test",
+      "name"     : "@scoped/test",
       "_rev"     : 1,
       "_proxied" : false
     };
@@ -1300,6 +1378,24 @@ describe('package npm functions', function () {
 
       request(app)
         .put('/proxied')
+        .set('Content-Type', 'application/json')
+        .send(pkgMeta)
+        .expect('Content-Type', 'application/json; charset=utf-8')
+        .expect(200, {"ok": true}, done);
+    });
+
+    it('publishes full scoped package meta json', function (done) {
+      sandbox.stub(registry, 'getPackage');
+      sandbox.stub(registry, 'setPackage');
+
+      var scopedProxied = require('./registry/@scoped/proxied/proxied.json');
+      pkgMeta = JSON.parse(JSON.stringify(scopedProxied));
+      pkgMeta['_mtime'] = new Date();
+
+      pkg.route(app);
+
+      request(app)
+        .put('/@scoped%2fproxied')
         .set('Content-Type', 'application/json')
         .send(pkgMeta)
         .expect('Content-Type', 'application/json; charset=utf-8')

--- a/test/registry/@scoped/proxied/pkg/.gitignore
+++ b/test/registry/@scoped/proxied/pkg/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/test/registry/@scoped/proxied/pkg/README.md
+++ b/test/registry/@scoped/proxied/pkg/README.md
@@ -1,0 +1,1 @@
+Some Readme about this test package.

--- a/test/registry/@scoped/proxied/pkg/index.js
+++ b/test/registry/@scoped/proxied/pkg/index.js
@@ -1,0 +1,4 @@
+/*! Copyright (C) 2014 by Andreas F. Bobak, Switzerland. All Rights Reserved. !*/
+"use strict";
+
+console.log('NOPAR Test Package/proxied');

--- a/test/registry/@scoped/proxied/pkg/package.json
+++ b/test/registry/@scoped/proxied/pkg/package.json
@@ -1,0 +1,25 @@
+{
+	"name": "@scoped/proxied",
+	"version": "2.0.0",
+	"description": "NOPAR Test Package/proxied",
+	"repository": {
+		"type": "git",
+		"url": "git@github.com:afbobak/test-pkg-proxied.git"
+	},
+	"homepage": "https://github.com/afbobak/test-pkg-proxied/",
+	"bugs": "https://github.com/afbobak/test-pkg-proxied/issues/",
+	"author": "Andreas F. Bobak <bobak@abstrakt.ch>",
+	"license": "BSD",
+	"main": "./index.js",
+	"dependencies": {
+		"semver": "^2.2"
+	},
+	"devDependencies": {
+		"chai": "^1.9",
+		"mocha": "^1.21",
+		"sinon": "^1.10"
+	},
+	"engines": {
+		"node": ">=0.10.25"
+	}
+}

--- a/test/registry/@scoped/proxied/pkg/run_test.sh
+++ b/test/registry/@scoped/proxied/pkg/run_test.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+npm cache clear
+npm config set registry http://localhost:5984/
+echo "===================================================="
+echo " Login in, should succeed"
+echo "===================================================="
+npm login
+echo "===================================================="
+echo " Installing dependencies, should succeed"
+echo "===================================================="
+npm install
+echo "===================================================="
+echo " Publishing to NOPAR, should succeed"
+echo "===================================================="
+npm publish
+echo "===================================================="
+echo " Re-Publishing to NOPAR, should fail"
+echo "===================================================="
+npm publish
+echo "===================================================="
+echo " Force-Publishing to NOPAR, should succeed"
+echo "===================================================="
+npm publish --force
+echo "===================================================="
+echo " Publishing new version to NOPAR, should succeed"
+echo "===================================================="
+mv package.json package.json.old
+sed -E 's/2\.0\.0/2\.0\.1/' package.json.old > package.json
+npm publish
+echo "===================================================="
+echo " Tagging old version on NOPAR, should succeed"
+echo "===================================================="
+npm tag proxied@2.0.0 older
+echo "===================================================="
+echo " Unpublishing version from NOPAR, should succeed"
+echo "===================================================="
+npm unpublish proxied@2.0.0
+echo "===================================================="
+echo " Force-Unpublishing from NOPAR, should succeed"
+echo "===================================================="
+npm unpublish --force
+
+cp package.json.old package.json
+rm package.json.old
+rm -fr node_modules

--- a/test/registry/@scoped/proxied/proxied.json
+++ b/test/registry/@scoped/proxied/proxied.json
@@ -1,0 +1,21 @@
+{
+	"_id":"@scoped/proxied",
+	"name":"@scoped/proxied",
+	"description":"NOPAR Test Package/proxied",
+	"dist-tags":{"latest":"2.0.0"},
+	"versions":{
+		"1.0.0":{"name":"@scoped/proxied","version":"1.0.0","description":"NOPAR Test Package/proxied","repository":{"type":"git","url":"git@github.com:afbobak/test-pkg-proxied.git"},"homepage":"https://github.com/afbobak/test-pkg-proxied/","bugs":{"url":"https://github.com/afbobak/test-pkg-proxied/issues/"},"author":{"name":"Andreas F. Bobak","email":"bobak@abstrakt.ch"},"license":"BSD","main":"./index.js","dependencies":{"semver":"^2.2"},"devDependencies":{"chai":"^1.9","mocha":"^1.21","sinon":"^1.10"},"engines":{"node":">=0.10.25"},"readme":"Some Readme about this test package.","readmeFilename":"README.md","_id":"proxied@1.0.0","_shasum":"4672b95ca47812c926aa9d66cd5540877a9e5e42","_from":".","_npmVersion":"1.4.9","_npmUser":{"name":"bobak","email":"afb@osares.com"},"maintainers":[{"name":"bobak","email":"afb@osares.com"}],"dist":{"shasum":"4672b95ca47812c926aa9d66cd5540877a9e5e42","tarball":"http://localhost:5984/@scoped/proxied/-/proxied-1.0.0.tgz"}},
+		"1.3.0":{"name":"@scoped/proxied","version":"1.3.0","description":"NOPAR Test Package/proxied","repository":{"type":"git","url":"git@github.com:afbobak/test-pkg-proxied.git"},"homepage":"https://github.com/afbobak/test-pkg-proxied/","bugs":{"url":"https://github.com/afbobak/test-pkg-proxied/issues/"},"author":{"name":"Andreas F. Bobak","email":"bobak@abstrakt.ch"},"license":"BSD","main":"./index.js","dependencies":{"semver":"^2.2"},"devDependencies":{"chai":"^1.9","mocha":"^1.21","sinon":"^1.10"},"engines":{"node":">=0.10.25"},"readme":"Some Readme about this test package.","readmeFilename":"README.md","_id":"proxied@1.3.0","_shasum":"49500e17405aae5f25d79df4d8eb57e0b6135734","_from":".","_npmVersion":"1.4.9","_npmUser":{"name":"bobak","email":"afb@osares.com"},"maintainers":[{"name":"bobak","email":"afb@osares.com"}],"dist":{"shasum":"49500e17405aae5f25d79df4d8eb57e0b6135734","tarball":"http://localhost:5984/@scoped/proxied/-/proxied-1.3.0.tgz"}},
+		"2.0.0":{"name":"@scoped/proxied","version":"2.0.0","description":"NOPAR Test Package/proxied","repository":{"type":"git","url":"git@github.com:afbobak/test-pkg-proxied.git"},"homepage":"https://github.com/afbobak/test-pkg-proxied/","bugs":{"url":"https://github.com/afbobak/test-pkg-proxied/issues/"},"author":{"name":"Andreas F. Bobak","email":"bobak@abstrakt.ch"},"license":"BSD","main":"./index.js","dependencies":{"semver":"^2.2"},"devDependencies":{"chai":"^1.9","mocha":"^1.21","sinon":"^1.10"},"engines":{"node":">=0.10.25"},"readme":"Some Readme about this test package.","readmeFilename":"README.md","_id":"proxied@2.0.0","_shasum":"7f9c1696c5d0484a1e226074701190e3fbcc00e0","_from":".","_npmVersion":"1.4.9","_npmUser":{"name":"bobak","email":"afb@osares.com"},"maintainers":[{"name":"bobak","email":"afb@osares.com"}],"dist":{"shasum":"7f9c1696c5d0484a1e226074701190e3fbcc00e0","tarball":"http://localhost:5984/@scoped/proxied/-/proxied-2.0.0.tgz"}}
+		},
+	"readme":"Some Readme about this test package.",
+	"maintainers":[{"name":"bobak","email":"afb@osares.com"}],
+	"_rev":3,
+	"_proxied":true,
+	"_mtime":"2014-10-27T03:13:23.000Z",
+	"_attachments":{
+		"proxied-1.0.0.tgz":{"cached":true,"forwardUrl":"http://localhost:5984/@scoped/proxied/-/proxied-1.0.0.tgz"},
+		"proxied-1.3.0.tgz":{"cached":true,"forwardUrl":"http://localhost:5984/@scoped/proxied/-/proxied-1.3.0.tgz"},
+		"proxied-2.0.0.tgz":{"cached":true,"forwardUrl":"http://localhost:5984/@scoped/proxied/-/proxied-2.0.0.tgz"}
+	}
+}

--- a/views/package.ejs
+++ b/views/package.ejs
@@ -18,14 +18,14 @@
         <%= pkgName %><small class="text-muted">@<%= latest.version %></small>
         <div class="actions btn-group">
           <a class="btn action-json btn-link btn-xs" href="<%= latest.dist.tarball %>"><span class="glyphicon glyphicon-download-alt"></span> Latest</a>
-          <a class="btn action-json btn-link btn-xs" href="/<%= pkgName %>">JSON</a>
+          <a class="btn action-json btn-link btn-xs" href="/<%= pkg.path %>">JSON</a>
         </div>
         <div class="actions btn-group">
          <% if (pkg["_proxied"]) { %>
-         <a class="btn btn-sm btn-link action-refresh" onclick="refreshPackage('<%= pkgName %>');" href="#">
+         <a class="btn btn-sm btn-link action-refresh" onclick="refreshPackage('<%= pkg.path %>');" href="#">
            <span class="glyphicon glyphicon-refresh"></span> Refresh
          </a><% } %>
-         <a class="btn btn-sm btn-link action-delete" onclick="deletePackage('<%= pkgName %>');" href="#">
+         <a class="btn btn-sm btn-link action-delete" onclick="deletePackage('<%= pkg.path %>');" href="#">
            <span class="glyphicon glyphicon-trash"></span> Delete Package
          </a>
         </div>

--- a/views/packages.ejs
+++ b/views/packages.ejs
@@ -19,7 +19,7 @@
            var latest = pkg.versions[pkg["dist-tags"].latest]; %>
          <li class="list-group-item">
           <h3>
-            <a href="/-/package/<%= pkgName %>"><%= pkgName %></a>
+            <a href="/-/package/<%= pkg.path %>"><%= pkgName %></a>
             <small class="text-muted">@<%= latest.version %></small>
             <small class="tags pull-right">
               <% if (pkg["_proxied"]) { %><div class="label label-warning">proxied</div><% } %>


### PR DESCRIPTION
Added basic support for scoped packages as discussed in #26 

Seems to work as far as I can tell, there's an empty package at https://www.npmjs.com/package/@glenjamin/simple-sse you can test with.

Have tested:
* Installing scoped package when not cached yet
* Installing scoped package when already cached
* publishing new scoped packages
* publishing updates to scoped packages
* Downloading cached and published attachments
* Browsing via web interface
* refresh / delete via interface

Edit: publishing turned out to be not much more, so I've folded into this PR.